### PR TITLE
Set up Coveralls [av skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Git"); Pkg.test("Git"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Git")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
+  - julia -e 'cd(Pkg.dir("Git")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Travis](https://travis-ci.org/JuliaPackaging/Git.jl.svg?branch=master)](https://travis-ci.org/JuliaPackaging/Git.jl)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/qw0kq3e4d6hua3q2/branch/master?svg=true)](https://ci.appveyor.com/project/ararslan/git-jl/branch/master)
-[![Codecov](https://codecov.io/gh/JuliaPackaging/Git.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaPackaging/Git.jl)
+[![Coveralls](https://coveralls.io/repos/github/JuliaPackaging/Git.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPackaging/Git.jl?branch=master)
 
 Julia wrapper for command line Git


### PR DESCRIPTION
Turns out Codecov changed the way they do things and now you have to put all of your settings in a file in the repo and set up a user bot to interact with their API. Luckily I finally got Coveralls to sync with my account, so let's go back to them.