### PR TITLE
Change is to ===

### DIFF
--- a/test/gitutils.jl
+++ b/test/gitutils.jl
@@ -19,7 +19,7 @@ function mktree(d::Dict)
         elseif isa(data, Dict)
             sha1 = mktree(data)
             lstree *= "040000 tree $sha1\t$name\n"
-        elseif is(data, nothing)
+        elseif data === nothing
             # ignore it
         else
             error("mktree: don't know what to do with $name => $data")
@@ -50,14 +50,14 @@ function verify_tree(d::Dict, tree::AbstractString)
     end
     # check that nothing was missing from tree
     for (name, data) in d
-        @test is(data,nothing) || in(name,seen)
+        @test data === nothing || in(name,seen)
     end
 end
 
 function verify_work(d::Dict)
     # check what's in d
     for (name, data) in d
-        if is(data, nothing)
+        if data === nothing
             @test !ispath(name)
             continue
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ try cd(dir) do
         git_setup(states[4:6]...)
         throw(nothing)
     end catch x
-        is(x,nothing) || rethrow()
+        x === nothing || rethrow()
     end
     git_verify(states[1:3]...)
 end


### PR DESCRIPTION
`is` is deprecated in Julia 0.6.