### PR TITLE
Changed Compat.UTF8String to String (#13)

### DIFF
--- a/src/Git.jl
+++ b/src/Git.jl
@@ -173,9 +173,9 @@ head(; dir="") = readchomp(`rev-parse HEAD`, dir=dir)
 
 
 immutable State
-    head::Compat.UTF8String
-    index::Compat.UTF8String
-    work::Compat.UTF8String
+    head::String
+    index::String
+    work::String
 end
 
 """


### PR DESCRIPTION
Simple change to avoid deprecation warnings (see #13 ).