### PR TITLE
Julia 1.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
 Compat 0.47.0
 BinDeps
+VersionParsing
 @osx Homebrew

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-Compat 0.8.4
+Compat 0.47.0
 BinDeps
 @osx Homebrew

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.6
-Compat 0.47.0
+julia 0.7
 BinDeps
 VersionParsing
 @osx Homebrew

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,21 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
     - master
     - /release-.*/
-
-skip_commits:
-  message: /\[av skip\]/
 
 notifications:
   - provider: Email
@@ -20,24 +24,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Git\"); Pkg.build(\"Git\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Git\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# Uncomment to support code coverage upload. Should only be enabled for packages
+# which would have coverage gaps without running on Windows
+on_success:
+  - echo "%JL_CODECOV_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,4 @@
-using Compat
-using Compat: @info
-using Compat.Sys: isapple, islinux, iswindows
-
+using Base.Sys: isapple, islinux, iswindows
 using BinDeps
 using BinDeps: download_cmd, unpack_cmd, splittarpath
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,19 @@
 using Compat
-import BinDeps: download_cmd, unpack_cmd, splittarpath
-if is_apple()
+using Compat: @info
+using Compat.Sys: isapple, islinux, iswindows
+
+using BinDeps
+using BinDeps: download_cmd, unpack_cmd, splittarpath
+
+if isapple()
     using Homebrew
 end
 
 function download_and_unpack(baseurl, filename)
     downloadurl = baseurl * filename
-    info("Downloading $filename from $downloadurl\nTo avoid this " *
-        "download, install git manually and add it to your path " *
-        "before\nrunning Pkg.add(\"Git\") or Pkg.build(\"Git\")")
+    @info "Downloading $filename from $downloadurl\nTo avoid this " *
+          "download, install git manually and add it to your path " *
+          "before\nrunning Pkg.add(\"Git\") or Pkg.build(\"Git\")"
     dest = joinpath("usr", string(Sys.MACHINE))
     for dir in ("downloads", "usr", dest)
         isdir(dir) || mkdir(dir)
@@ -17,23 +22,24 @@ function download_and_unpack(baseurl, filename)
     isfile(filename) || run(download_cmd(downloadurl, filename))
     # TODO: checksum validation
     (b, ext, sec_ext) = splittarpath(filename)
-    run(unpack_cmd(filename, dest, is_windows() ? ".7z" : ext, sec_ext))
+    run(unpack_cmd(filename, dest, iswindows() ? ".7z" : ext, sec_ext))
     # TODO: make this less noisy on windows, see how WinRPM does it
 end
 
 gitcmd = `git`
 gitver = "notfound"
 try
-    gitver = readchomp(`$gitcmd --version`)
+    global gitver = readchomp(`$gitcmd --version`)
+catch
 end
 if gitver == "notfound"
-    if is_apple()
+    if isapple()
         # we could allow other options, but lots of other packages already
         # depend on Homebrew.jl on mac and it needs a working git to function
         error("Working git not found on path, try running\nPkg.build(\"Homebrew\")")
     end
     baseurl = ""
-    if is_linux() && (Sys.ARCH in (:x86_64, :i686, :i586, :i486, :i386))
+    if islinux() && (Sys.ARCH in (:x86_64, :i686, :i586, :i486, :i386))
         # use conda for a non-root option on x86/amd64 linux
         # TODO? use conda-forge when we no longer build julia on centos 5
         gitver = "2.6.4"
@@ -47,7 +53,7 @@ if gitver == "notfound"
         zlibver = "1.2.8"
         zlibbase = "http://anaconda.org/anaconda/zlib/$zlibver/$plat"
         download_and_unpack(zlibbase, "zlib-$zlibver-3.tar.bz2")
-    elseif is_windows()
+    elseif iswindows()
         # download and extract portablegit
         gitver = "2.9.0"
         baseurl = "https://github.com/git-for-windows/git/releases/download/"
@@ -59,24 +65,27 @@ if gitver == "notfound"
         gitcmd = `$gitpath`
     end
     try
-        gitver = readchomp(`$gitcmd --version`)
-        info("Successfully installed $gitver to $gitcmd")
+        global gitver = readchomp(`$gitcmd --version`)
+        @info "Successfully installed $gitver to $gitcmd"
         # TODO: fix a warning about missing /templates here on linux
         # by setting an environment variable in deps.jl
     catch err
-        error("Could not automatically install git, error was: $err\n" *
-            (is_windows() ? "Report an issue at https://github.com/JuliaPackaging/Git.jl/issues/new" :
-            "Try installing git via your system package manager then running\nPkg.build(\"Git\")"))
+        s = if iswindows()
+            "Report an issue at https://github.com/JuliaPackaging/Git.jl/issues/new"
+        else
+            "Try installing git via your system package manager then running\nPkg.build(\"Git\")"
+        end
+        error("Could not automatically install git, error was: $err\n" * s)
     end
 else
     try
         # this is in a try because some environments like centos 7
         # docker containers don't have `which` installed by default
-        gitpath = chomp(readlines(is_windows() ? `where git` : `which git`)[1])
-        gitcmd = `$gitpath`
+        global gitpath = chomp(readlines(iswindows() ? `where git` : `which git`)[1])
+        global gitcmd = `$gitpath`
+    catch
     end
-    info("Using $gitver found on path" * (gitcmd == `git` ?
-        "" : " at $gitcmd"))
+    @info "Using $gitver found on path" * (gitcmd == `git` ? "" : " at $gitcmd")
 end
 open("deps.jl", "w") do f
     println(f, "gitcmd = $gitcmd")

--- a/src/Git.jl
+++ b/src/Git.jl
@@ -5,7 +5,7 @@ module Git
 # some utility functions for working with git repos
 #
 using Compat
-import Base: shell_escape
+using Base: shell_escape
 export gitcmd # determined by deps/build.jl and saved in deps/deps.jl
 
 depsjl = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
@@ -47,12 +47,12 @@ Return a Git command from the given arguments, acting on the repository given in
 cmd(args::Cmd; dir="") = `$(git(dir)) $args`
 
 """
-    Git.run(args; dir="", out=STDOUT)
+    Git.run(args; dir="", out=stdout)
 
 Execute the Git command from the given arguments `args` on the repository `dir`, writing
 the results to the output stream `out`.
 """
-run(args::Cmd; dir="", out=STDOUT) = Base.run(pipeline(cmd(args,dir=dir), out))
+run(args::Cmd; dir="", out=stdout) = Base.run(pipeline(cmd(args,dir=dir), out))
 
 """
     Git.readstring(args; dir="")
@@ -60,7 +60,7 @@ run(args::Cmd; dir="", out=STDOUT) = Base.run(pipeline(cmd(args,dir=dir), out))
 Read the result of the Git command using the given arguments on the given repository
 as a string.
 """
-readstring(args::Cmd; dir="") = Base.readstring(cmd(args,dir=dir))
+readstring(args::Cmd; dir="") = read(cmd(args,dir=dir), String)
 
 """
     Git.readchomp(args; dir="")
@@ -147,7 +147,7 @@ single SHA1 or a vector of SHA1s.
 """
 iscommit(name; dir="") = success(`cat-file commit $name`, dir=dir)
 function iscommit(sha1s::Vector; dir="")
-    indexin(sha1s,split(readchomp(`log --all --format=%H`, dir=dir),"\n")).!=0
+    indexin(sha1s,split(readchomp(`log --all --format=%H`, dir=dir),"\n")).!=nothing
 end
 
 """
@@ -172,7 +172,7 @@ Return the commit to which HEAD currently refers.
 head(; dir="") = readchomp(`rev-parse HEAD`, dir=dir)
 
 
-immutable State
+struct State
     head::String
     index::String
     work::String

--- a/src/Git.jl
+++ b/src/Git.jl
@@ -4,7 +4,6 @@ module Git
 #
 # some utility functions for working with git repos
 #
-using Compat
 using Base: shell_escape
 using VersionParsing
 export gitcmd # determined by deps/build.jl and saved in deps/deps.jl

--- a/src/Git.jl
+++ b/src/Git.jl
@@ -6,6 +6,7 @@ module Git
 #
 using Compat
 using Base: shell_escape
+using VersionParsing
 export gitcmd # determined by deps/build.jl and saved in deps/deps.jl
 
 depsjl = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
@@ -88,15 +89,7 @@ end
 
 Return the version of Git being used by the package.
 """
-function version()
-    vs = split(readchomp(`version`), ' ')[3]
-    ns = split(vs, '.')
-    if length(ns) > 3
-        VersionNumber(join(ns[1:3], '.'))
-    else
-        VersionNumber(join(ns, '.'))
-    end
-end
+version() = vparse(readchomp(`version`))
 
 """
     Git.modules(args; dir="")

--- a/test/gitutils.jl
+++ b/test/gitutils.jl
@@ -1,24 +1,12 @@
 # This file was a part of Julia. License is MIT: http://julialang.org/license
 
-using Compat
-
-if VERSION >= v"0.7.0-DEV.3427"
-    function write_and_readchomp(data, cmd::Cmd)
-        p = open(cmd, "r+")
-        print(p.in, data)
-        close(p.in)
-        v = readchomp(p.out)
-        wait(p)
-        return v
-    end
-else
-    function write_and_readchomp(data, cmd::Cmd)
-        r, w, p = readandwrite(cmd)
-        print(w,data); close(w)
-        v = readchomp(r)
-        wait(p)
-        return v
-    end
+function write_and_readchomp(data, cmd::Cmd)
+    p = open(cmd, "r+")
+    print(p.in, data)
+    close(p.in)
+    v = readchomp(p.out)
+    wait(p)
+    return v
 end
 
 function mktree(d::Dict)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,7 @@
 # This file was a part of Julia. License is MIT: http://julialang.org/license
 
 using Git
-using Compat
-using Compat.Test
+using Test
 
 include("gitutils.jl")
 
@@ -24,11 +23,7 @@ mktempdir() do dir
 
         contents = [nothing, "foo", "bar", Dict{Any,Any}("baz"=>"qux")]
         b = length(contents)
-        @static if VERSION >= v"0.7.0"
-            states = [Dict([(string(k, base=b, pad=6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
-        else
-            states = [Dict([(base(b, k, 6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
-        end
+        states = [Dict([(string(k, base=b, pad=6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
 
         git_setup(states[1:3]...)
         try Git.transact() do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,42 +1,42 @@
 # This file was a part of Julia. License is MIT: http://julialang.org/license
 
 using Git
-using Base.Test
+using Compat
+using Compat.Test
 
 include("gitutils.jl")
 
 @test Git.version() >= v"1.7.3"
 
-dir = string("tmp.",randstring())
-@test !ispath(dir)
-mkdir(dir)
-@test isdir(dir)
-try cd(dir) do
-    run(`$gitcmd init -q`)
-    run(`$gitcmd config user.name "Julia Tester"`)
-    run(`$gitcmd config user.email test@julialang.org`)
-    run(`$gitcmd commit -q --allow-empty -m "initial empty commit"`)
-    git_verify(Dict(), Dict(), Dict())
+mktempdir() do dir
+    cd(dir) do
+        run(`$gitcmd init -q`)
+        run(`$gitcmd config user.name "Julia Tester"`)
+        run(`$gitcmd config user.email test@julialang.org`)
+        run(`$gitcmd commit -q --allow-empty -m "initial empty commit"`)
+        git_verify(Dict(), Dict(), Dict())
 
-    # each path can have one of these content in each of head, index, work
-    # for a total of length(contents)^3 = 4^3 = 64 combinations.
-    # each path can be in any of these 64 "superpositions" before & after
-    # for a total of 64^2 = 4096 files needed to test all transitions
-    # between before and after superpositions of git repo states.
+        # each path can have one of these content in each of head, index, work
+        # for a total of length(contents)^3 = 4^3 = 64 combinations.
+        # each path can be in any of these 64 "superpositions" before & after
+        # for a total of 64^2 = 4096 files needed to test all transitions
+        # between before and after superpositions of git repo states.
 
-    contents = [nothing, "foo", "bar", Dict{Any,Any}("baz"=>"qux")]
-    b = length(contents)
-    states = [Dict([(base(b,k,6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
+        contents = [nothing, "foo", "bar", Dict{Any,Any}("baz"=>"qux")]
+        b = length(contents)
+        @static if VERSION >= v"0.7.0"
+            states = [Dict([(string(k, base=b, pad=6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
+        else
+            states = [Dict([(base(b, k, 6), contents[rem(div(k,b^p),b)+1]) for k=0:(b^3)^2-1]) for p=0:5]
+        end
 
-    git_setup(states[1:3]...)
-    try Git.transact() do
-        git_setup(states[4:6]...)
-        throw(nothing)
-    end catch x
-        x === nothing || rethrow()
+        git_setup(states[1:3]...)
+        try Git.transact() do
+            git_setup(states[4:6]...)
+            throw(nothing)
+        end catch x
+            x === nothing || rethrow()
+        end
+        git_verify(states[1:3]...)
     end
-    git_verify(states[1:3]...)
-end
-finally
-    rm(dir, recursive=true)
 end


### PR DESCRIPTION
This PR makes Git.jl run under Julia 1.0 (issue #20). It is a continuation of #18.

* I have "issues" running the tests. They should work, but they seem to take forever (in particular `mktree`). Has this always been the case? I only quickly checked with Julia 0.6 and also aborted tests after ~10 minutes there.
* It would be nice to check the build script under linux / macos (no previous git installation). But perhaps it is fine to merge and wait for user complains. After all, this package doesn't seem to be used by many.